### PR TITLE
Fix support for solidus 3+ and Rails 7

### DIFF
--- a/lib/solidus_razorpay/engine.rb
+++ b/lib/solidus_razorpay/engine.rb
@@ -12,14 +12,17 @@ module SolidusRazorpay
     engine_name 'solidus_razorpay'
 
     initializer "solidus_razorpay.add_static_preference", after: "spree.register.payment_methods" do |app|
-      app.config.spree.payment_methods << SolidusRazorpay::RazorpayPayment
-      Spree::Config.static_model_preferences.add(
-        SolidusRazorpay::RazorpayPayment,
-        'razorpay_credentials', {
-          razorpay_key: ENV['RAZORPAY_KEY'],
-          razorpay_secret: ENV['RAZORPAY_SECRET']
-        }
-      )
+      app.config.spree.payment_methods << 'SolidusRazorpay::RazorpayPayment'
+
+      app.config.to_prepare do
+        Spree::Config.static_model_preferences.add(
+          SolidusRazorpay::RazorpayPayment,
+          'razorpay_credentials', {
+            razorpay_key: ENV['RAZORPAY_KEY'],
+            razorpay_secret: ENV['RAZORPAY_SECRET']
+          }
+        )
+      end
       Spree::PermittedAttributes.source_attributes.concat [
         :razorpay_order_id,
         :razorpay_payment_id,

--- a/lib/solidus_razorpay/version.rb
+++ b/lib/solidus_razorpay/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusRazorpay
-  VERSION = '0.0.1'
+  VERSION = '0.1.0'
 end

--- a/solidus_razorpay.gemspec
+++ b/solidus_razorpay.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/piyushswain/solidus_razorpay'
   spec.metadata['changelog_uri'] = 'https://github.com/piyushswain/solidus_razorpay/blob/main/CHANGELOG.md'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
This PR aims to fix the extension to support Rails 7 and Solidus 3+

- [x] Fix errors on running the installer in Rails 7 and Solidus 3+. (Added `to_prepare` block to fix loading errors on static sources)
- [x] Update supported Ruby versions (Updated support to Ruby 2.5+)
- [x] Bump extension version (Bumped version to 0.1.0)